### PR TITLE
Added `options` to the `local_time_ago` helper

### DIFF
--- a/app/helpers/local_time_helper.rb
+++ b/app/helpers/local_time_helper.rb
@@ -14,9 +14,13 @@ module LocalTimeHelper
     local_time time, options
   end
 
-  def local_time_ago(time)
+  def local_time_ago(time, options = {})
     time = utc_time(time)
-    time_tag time, time.strftime('%B %e, %Y %l:%M%P'), data: { local: 'time-ago' }
+
+    options[:data] ||= {}
+    options[:data].merge! local: 'time-ago'
+
+    time_tag time, time.strftime('%B %e, %Y %l:%M%P'), options
   end
 
   def utc_time(time_or_date)

--- a/test/helpers/local_time_helper_test.rb
+++ b/test/helpers/local_time_helper_test.rb
@@ -65,4 +65,9 @@ class LocalTimeHelperTest < MiniTest::Unit::TestCase
     expected = %Q(<time data-local="time-ago" datetime="#{@time_js}">November 21, 2013  6:00am</time>)
     assert_equal expected, local_time_ago(@time)
   end
+
+  def test_local_time_ago_with_options
+    expected = %Q(<time class="date-time" data-local="time-ago" datetime="#{@time_js}">November 21, 2013  6:00am</time>)
+    assert_equal expected, local_time_ago(@time, class: "date-time")
+  end
 end


### PR DESCRIPTION
Allows calls to pass in options (e.g. `class`)
