### PR TITLE
accept i18n format symbol

### DIFF
--- a/app/helpers/local_time_helper.rb
+++ b/app/helpers/local_time_helper.rb
@@ -1,10 +1,14 @@
 module LocalTimeHelper
   def local_time(time, options = {})
     time   = utc_time(time)
-    format = options.delete(:format).presence || '%B %e, %Y %l:%M%P'
-    if format.kind_of?(Symbol)
-      format = Time::DATE_FORMATS[format]
+    format = options.delete(:format).presence
+    if format.is_a?(Symbol)
+      format = Time::DATE_FORMATS[format] || I18n.t("time.formats.#{format}")
+      if !format.is_a?(String) || format =~ /\Atranslation missing/
+        format = nil
+      end
     end
+    format ||= '%B %e, %Y %l:%M%P'
 
     options[:data] ||= {}
     options[:data].merge! local: :time, format: format

--- a/test/helpers/local_time_helper_test.rb
+++ b/test/helpers/local_time_helper_test.rb
@@ -51,6 +51,24 @@ class LocalTimeHelperTest < MiniTest::Unit::TestCase
     assert_equal expected, local_time(@time, format: :simple)
   end
 
+  def test_local_time_with_format_symbol_and_i18n
+    I18n.backend.store_translations(:en, {:time => {:formats => {:simple => "%b %e"}}})
+    expected = %Q(<time data-format="%b %e" data-local="time" datetime="#{@time_js}">Nov 21</time>)
+    assert_equal expected, local_time(@time, format: :simple)
+  end
+
+  def test_local_time_with_fomrat_symbol_defaults_when_proc
+    Time::DATE_FORMATS[:proc] = proc {|time| "nope" }
+    expected = %Q(<time data-format="%B %e, %Y %l:%M%P" data-local="time" datetime="#{@time_js}">November 21, 2013  6:00am</time>)
+    assert_equal expected, local_time(@time, format: :proc)
+  end
+
+  def test_local_time_with_fomrat_symbol_defaults_when_proc_i18n
+    I18n.backend.store_translations(:en, {:time => {:formats => proc {|time| "nope" } }})
+    expected = %Q(<time data-format="%B %e, %Y %l:%M%P" data-local="time" datetime="#{@time_js}">November 21, 2013  6:00am</time>)
+    assert_equal expected, local_time(@time, format: :proc)
+  end
+
   def test_local_time_with_options
     expected = %Q(<time data-format="%b %e" data-local="time" datetime="#{@time_js}" style="display:none">Nov 21</time>)
     assert_equal expected, local_time(@time, format: '%b %e', style: 'display:none')


### PR DESCRIPTION
Allow passing in a symbol for format:

``` erb
<%= local_time(comment.created_at, format: :db) %>
```

This probably isn't mergable as-is. Thoughts on a better way?
