### PR TITLE
Register jQuery ajaxSuccess even if Turbolinks present

### DIFF
--- a/app/assets/javascripts/local_time.js.coffee
+++ b/app/assets/javascripts/local_time.js.coffee
@@ -161,8 +161,8 @@ update = (callback) ->
       window.addEventListener "popstate", callback
     , 1
 
-    jQuery?(document).on "ajaxSuccess", (event, xhr) ->
-      callback() if jQuery.trim xhr.responseText
+  jQuery?(document).on "ajaxSuccess", (event, xhr) ->
+    callback() if jQuery.trim xhr.responseText
 
 process = (selector, callback) ->
   update ->


### PR DESCRIPTION
Just because an app uses Turbolinks doesn't mean it doesn't also make use of jQuery ajax. Always register the local_time callback to execute on jQuery's ajaxSuccess event if jQuery is present.
