### PR TITLE
add local_time_count_down to gem

### DIFF
--- a/app/assets/javascripts/local_time.js.coffee
+++ b/app/assets/javascripts/local_time.js.coffee
@@ -143,8 +143,60 @@ class RelativeTimeAgo
   formatTime: ->
     strftime @date, '%l:%M%P'
 
+class RelativeTimeCountdown
+  constructor: (@date) ->
+    @calendarDate = CalendarDate.fromDate @date
+
+  toString: ->
+    current = new Date().getTime()
+    startDate = @date.getTime()
+
+    if current > startDate
+      @timePastGap()
+    else
+      @timeFutureGap()
+
+  timePastGap: ->
+    ms  = @date.getTime() -  new Date().getTime()
+    diff = Math.round ms  / 1000
+    seconds = diff % 60
+    minutes = ( ( diff - seconds ) / 60 ) % 60
+    hours = ( ( ( ( diff - ( minutes * 60 ) ) - seconds ) / 60 ) / 60 ) % 24
+
+    seconds = Math.abs(seconds)
+    minutes = Math.abs(minutes)
+    hours = Math.abs(hours)
+
+    if diff > -60
+      "#{seconds}s ago"
+    else if diff > -3600
+      "#{minutes}m ago"
+    else if diff <= -3600 and minutes == 0
+      "#{hours}h ago"
+    else if diff < -3600 and minutes != 0
+      "#{hours}h#{minutes}m ago"
+
+  timeFutureGap: ->
+    ms  = @date.getTime() -  new Date().getTime()
+    diff = Math.round ms  / 1000
+    seconds = diff % 60
+    minutes = ( ( diff - seconds ) / 60 ) % 60
+    hours = ( ( ( ( diff - ( minutes * 60 ) ) - seconds ) / 60 ) / 60 ) % 24
+
+    if diff > 3600 and minutes != 0
+      "#{hours}h#{minutes}m"
+    else if diff >= 3600 and minutes == 0
+      "#{hours}h"
+    else if diff >= 60
+      "#{minutes}m"
+    else if diff > -60
+      "#{seconds}s"
+
 relativeTimeAgo = (date) ->
   new RelativeTimeAgo(date).toString()
+
+relativeTimeCountdown = (date) ->
+  new RelativeTimeCountdown(date).toString()
 
 domLoaded = false
 
@@ -187,12 +239,14 @@ document.addEventListener "DOMContentLoaded", ->
           strftime time, format
         when "time-ago"
           relativeTimeAgo time
+        when "time-count-down"
+          relativeTimeCountdown time
 
   setInterval ->
     event = document.createEvent "Events"
     event.initEvent "time:elapse", true, true
     document.dispatchEvent event
-  , 60 * 1000
+  , 1000
 
 # Public API
 @LocalTime = {strftime, relativeTimeAgo}

--- a/app/helpers/local_time_helper.rb
+++ b/app/helpers/local_time_helper.rb
@@ -33,6 +33,15 @@ module LocalTimeHelper
     end
   end
 
+  def local_time_count_down(time, options = {})
+    time = utc_time(time)
+
+    options[:data] ||= {}
+    options[:data].merge! local: 'time-count-down'
+
+    time_tag time, time.strftime(DEFAULT_FORMAT), options
+  end
+
   private
     def time_format(format)
       if format.is_a?(Symbol)

--- a/test/helpers/local_time_helper_test.rb
+++ b/test/helpers/local_time_helper_test.rb
@@ -108,6 +108,11 @@ class LocalTimeHelperTest < MiniTest::Unit::TestCase
     assert_equal expected, local_time_ago(@time)
   end
 
+  def test_local_time_count_down
+    expected = %Q(<time data-local="time-count-down" datetime="#{@time_js}">November 21, 2013  6:00am</time>)
+    assert_equal expected, local_time_count_down(@time)
+  end
+
   def test_local_time_ago_with_options
     expected = %Q(<time class="date-time" data-local="time-ago" datetime="#{@time_js}">November 21, 2013  6:00am</time>)
     assert_equal expected, local_time_ago(@time, class: "date-time")

--- a/test/javascripts/index.html
+++ b/test/javascripts/index.html
@@ -17,4 +17,5 @@
   <time id="date" data-format="%B %e, %Y" data-local="time" datetime="2013-11-12T12:13:00Z"></time>
 
   <time id="ago"></time>
+  <time id="count-down"></time>
 </html>

--- a/test/javascripts/unit/time_count_down_test.js.coffee
+++ b/test/javascripts/unit/time_count_down_test.js.coffee
@@ -1,0 +1,47 @@
+module "time count down"
+
+test "9s ago", ->
+  assertTimeCountDownPast "9s ago", "seconds", 9
+
+test "1m ago", ->
+  assertTimeCountDownPast "1m ago", "seconds", 89
+
+test "59m ago", ->
+  assertTimeCountDownPast "59m ago", "minutes", 59
+
+test "1h ago", ->
+  assertTimeCountDownPast "1h ago", "minutes", 60
+
+test "1h5m ago", ->
+  assertTimeCountDownPast "1h5m ago", "minutes", 65
+
+
+test "9s", ->
+  assertTimeCountDownFuture "9s", "seconds", 9
+
+test "1m", ->
+  assertTimeCountDownFuture "1m", "seconds", 60
+
+test "59m", ->
+  assertTimeCountDownFuture "59m", "minutes", 59
+
+test "1h", ->
+  assertTimeCountDownFuture "1h", "minutes", 60
+
+test "1h5m", ->
+  assertTimeCountDownFuture "1h5m", "minutes", 65
+  
+
+assertTimeCountDownPast = (string, unit, amount) ->
+  el = document.getElementById "count-down"
+  el.setAttribute "data-local", "time-count-down"
+  el.setAttribute "datetime", moment().subtract(unit, amount).utc().toISOString()
+  run()
+  equal getText(el), string
+
+assertTimeCountDownFuture = (string, unit, amount) ->
+  el = document.getElementById "count-down"
+  el.setAttribute "data-local", "time-count-down"
+  el.setAttribute "datetime", moment().add(unit, amount).utc().toISOString()
+  run()
+  equal getText(el), string


### PR DESCRIPTION
*many project need time period instead of specific
time point value. after add local_time_count_down helper
you could use this helper compare the time value with now
*change refresh frequency to 1s
*this updated gem could be use any racing project time count down staff

@lsylvester 
