### PR TITLE
localizing javascript to consider i18n day and month names

### DIFF
--- a/app/assets/javascripts/local_time.js.coffee.erb
+++ b/app/assets/javascripts/local_time.js.coffee.erb
@@ -16,8 +16,8 @@ if isNaN Date.parse "2011-01-01T12:00:00-05:00"
       dateString = "#{year}/#{month}/#{day} #{hour}:#{minute}:#{second} GMT#{[offset]}"
     parse dateString
 
-weekdays = "Sunday Monday Tuesday Wednesday Thursday Friday Saturday".split " "
-months   = "January February March April May June July August September October November December".split " "
+weekdays = <%= I18n.t('date.day_names') %>
+months   = <%= I18n.t('date.month_names') %>
 
 pad = (num) -> ('0' + num).slice -2
 


### PR DESCRIPTION
Renamed javascript allowing embedding of ruby code to take day names and month names from I18n api. It works, as suggested by user javan at #7.
