### PR TITLE
Add ordinal functionality to format string

### DIFF
--- a/app/assets/javascripts/local_time.js.coffee
+++ b/app/assets/javascripts/local_time.js.coffee
@@ -21,6 +21,13 @@ months   = "January February March April May June July August September October 
 
 pad = (num) -> ('0' + num).slice -2
 
+ordinal = (number) ->
+  switch number % 10
+    when 1 then 'st'
+    when 2 then 'nd'
+    when 3 then 'rd'
+    else 'th'
+
 strftime = (time, formatString) ->
   day    = time.getDay()
   date   = time.getDate()
@@ -30,7 +37,7 @@ strftime = (time, formatString) ->
   minute = time.getMinutes()
   second = time.getSeconds()
 
-  formatString.replace /%([%aAbBcdeHIlmMpPSwyYZ])/g, ([match, modifier]) ->
+  formatString.replace /%([%aAbBcdeEHIlmMpPSwyYZ])/g, ([match, modifier]) ->
     switch modifier
       when '%' then '%'
       when 'a' then weekdays[day].slice 0, 3
@@ -40,6 +47,7 @@ strftime = (time, formatString) ->
       when 'c' then time.toString()
       when 'd' then pad date
       when 'e' then date
+      when 'E' then date + ordinal(date)
       when 'H' then pad hour
       when 'I' then pad strftime time, '%l'
       when 'l' then (if hour is 0 or hour is 12 then 12 else (hour + 12) % 12)
@@ -52,7 +60,6 @@ strftime = (time, formatString) ->
       when 'y' then pad year % 100
       when 'Y' then year
       when 'Z' then time.toString().match(/\((\w+)\)$/)?[1] ? ''
-
 
 class CalendarDate
   @fromDate: (date) ->

--- a/test/javascripts/local_time/strftime_test.js.coffee
+++ b/test/javascripts/local_time/strftime_test.js.coffee
@@ -46,3 +46,19 @@ for day in [0..30] by 6
           text = getText el
           ok /^\w{3,4}$/.test(text), "#{text} doesn't look like a timezone"
 
+ordinalMap =
+  "st": [1,11,21,31]
+  "nd": [2,12,22]
+  "rd": [3,13,23]
+  "th": [4,5,6,7,8,9,10,14,15,16,17,18,19,20,30]
+
+for expectedOrdinal, days of ordinalMap
+  do (days, expectedOrdinal) ->
+    for day in days
+      do (day) ->
+        test "%E", ->
+          date = new Date(2014, 0, day)
+          el  = addTimeEl {format: "%E", datetime: date.toISOString()}
+          run()
+
+          equal getText(el), day + expectedOrdinal


### PR DESCRIPTION
Ordinals often make dates more pleasant to read ('3rd', '14th'). I have used the format string character `E` because it is close to the normal date string (`e`), but also unused in Ruby (in std C it is a 'modifier', but according to the [Ruby documentation](http://www.ruby-doc.org/core-2.1.1/Time.html#method-i-strftime), it is ignored)
