### PR TITLE
Consistently use UTC dates in CalendarDate

### DIFF
--- a/app/assets/javascripts/local_time.js.coffee
+++ b/app/assets/javascripts/local_time.js.coffee
@@ -56,7 +56,7 @@ strftime = (time, formatString) ->
 
 class CalendarDate
   @fromDate: (date) ->
-    new this date.getFullYear(), date.getMonth() + 1, date.getDate()
+    new this date.getUTCFullYear(), date.getUTCMonth() + 1, date.getUTCDate()
 
   @today: ->
     @fromDate new Date


### PR DESCRIPTION
In this example, the UTC dates are only one day apart. However, because the first falls at 5:59 AM and my local timezone (Mountain) is UTC-0600, its local date is two days away.

``` js
then = new Date('2014-06-23T05:59:59.117Z')
// => Sun Jun 22 2014 23:59:59 GMT-0600 (MDT)
now = new Date('2014-06-24T17:15:45.117Z')
// => Tue Jun 24 2014 11:15:45 GMT-0600 (MDT)

CalendarDate.fromDate(then).date
// => Sat Jun 21 2014 18:00:00 GMT-0600 (MDT)
CalendarDate.fromDate(now).date
// => Mon Jun 23 2014 18:00:00 GMT-0600 (MDT)
```

The fromDate factory method that converts a Date to CalendarDate just needs to use UTC to match the CalendarDate constructor. This fixes the `daysPassed` calculation.
