### PR TITLE
Set time span in which time is displayed relatively

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ Examples (in quotes):
 * This year: "on Nov 17"
 * Last year: "on Jan 31, 2012"
 
+Time period in which time will be displayed relatively can be passed as an options hash.
+
+Example:
+
+```erb
+<%= local_time_ago(time, span: 48) %>
+```
+
 #### Relative time helper
 
 Preset time and date formats that vary with age. The available types are `date`, `time-ago`, `time-or-date`, and `weekday`. Like the `local_time` helper, `:type` can be passed a string or in an options hash.

--- a/app/assets/javascripts/local_time.js.coffee
+++ b/app/assets/javascripts/local_time.js.coffee
@@ -94,7 +94,7 @@ class CalendarDate
 
 
 class RelativeTime
-  constructor: (@date) ->
+  constructor: (@date, @span) ->
     @calendarDate = CalendarDate.fromDate @date
 
   toString: ->
@@ -135,7 +135,7 @@ class RelativeTime
       "#{min} minutes"
     else if min < 90
       "an hour"
-    else if hr < 24
+    else if hr < @span
       "#{hr} hours"
     else
       null
@@ -160,8 +160,8 @@ class RelativeTime
 relativeDate = (date) ->
   new RelativeTime(date).formatDate()
 
-relativeTimeAgo = (date) ->
-  new RelativeTime(date).toString()
+relativeTimeAgo = (date, span) ->
+  new RelativeTime(date, span).toString()
 
 relativeTimeOrDate = (date) ->
   new RelativeTime(date).toTimeOrDateString()
@@ -197,6 +197,7 @@ document.addEventListener "DOMContentLoaded", ->
     datetime = element.getAttribute "datetime"
     format   = element.getAttribute "data-format"
     local    = element.getAttribute "data-local"
+    span     = element.getAttribute "data-span"
 
     time = new Date Date.parse datetime
     return if isNaN time
@@ -213,7 +214,7 @@ document.addEventListener "DOMContentLoaded", ->
           element.setAttribute "data-localized", true
           strftime time, format
         when "time-ago"
-          relativeTimeAgo time
+          relativeTimeAgo time, parseInt(span)
         when "time-or-date"
           relativeTimeOrDate time
         when "weekday"

--- a/app/helpers/local_time_helper.rb
+++ b/app/helpers/local_time_helper.rb
@@ -22,9 +22,11 @@ module LocalTimeHelper
   def local_relative_time(time, options = nil)
     time = utc_time(time)
     options, type = extract_options_and_value(options, :type)
+    options, span = extract_options_and_value(options, :span)
 
     options[:data] ||= {}
     options[:data].merge! local: type
+    options[:data].merge! span: span || 24
 
     time_tag time, time.strftime(DEFAULT_FORMAT), options
   end

--- a/test/helpers/local_time_helper_test.rb
+++ b/test/helpers/local_time_helper_test.rb
@@ -125,22 +125,27 @@ class LocalTimeHelperTest < TestCase
   end
 
   def test_local_time_ago
-    expected = %Q(<time data-local="time-ago" datetime="#{@time_js}">November 21, 2013  6:00am</time>)
+    expected = %Q(<time data-local="time-ago" data-span="24" datetime="#{@time_js}">November 21, 2013  6:00am</time>)
     assert_dom_equal expected, local_time_ago(@time)
   end
 
   def test_local_time_ago_with_options
-    expected = %Q(<time class="date-time" data-local="time-ago" datetime="#{@time_js}">November 21, 2013  6:00am</time>)
+    expected = %Q(<time class="date-time" data-local="time-ago" data-span="24" datetime="#{@time_js}">November 21, 2013  6:00am</time>)
     assert_dom_equal expected, local_time_ago(@time, class: "date-time")
   end
 
+  def test_local_time_ago_with_custom_hours_span
+    expected = %Q(<time data-local="time-ago" data-span="48" datetime="#{@time_js}">November 21, 2013  6:00am</time>)
+    assert_dom_equal expected, local_time_ago(@time, span: "48")
+  end
+
   def test_relative_time
-    expected = %Q(<time data-local="time-or-date" datetime="#{@time_js}">November 21, 2013  6:00am</time>)
+    expected = %Q(<time data-local="time-or-date" data-span="24" datetime="#{@time_js}">November 21, 2013  6:00am</time>)
     assert_dom_equal expected, local_relative_time(@time, type: "time-or-date")
   end
 
   def test_local_time_ago_with_type_as_string
-    expected = %Q(<time data-local="time-or-date" datetime="#{@time_js}">November 21, 2013  6:00am</time>)
+    expected = %Q(<time data-local="time-or-date" data-span="24" datetime="#{@time_js}">November 21, 2013  6:00am</time>)
     assert_dom_equal expected, local_relative_time(@time, "time-or-date")
   end
 end

--- a/test/javascripts/local_time/time_ago_test.js.coffee
+++ b/test/javascripts/local_time/time_ago_test.js.coffee
@@ -46,6 +46,7 @@ test "next year", ->
 assertTimeAgo = (string, unit, amount) ->
   el = document.getElementById "ago"
   el.setAttribute "data-local", "time-ago"
+  el.setAttribute "data-span", "24"
   el.setAttribute "datetime", moment().subtract(unit, amount).utc().toISOString()
   run()
   equal getText(el), string


### PR DESCRIPTION
At the moment time that passed is displayed only within 24 hours, after that some sort of date is displayed, it would be nice if users could customize it.