### PR TITLE
Add new type: 'close-weekday-or-date'

### DIFF
--- a/app/assets/javascripts/local_time.js.coffee
+++ b/app/assets/javascripts/local_time.js.coffee
@@ -157,6 +157,15 @@ class RelativeTime
         "yesterday"
       when 2,3,4,5,6
         strftime @date, "%A"
+  
+  relativeCloseWeekday: ->
+    switch @calendarDate.daysPassed()
+      when 0
+        "today"
+      when 1
+        "yesterday"
+      when -1
+        "tomorrow"
 
   formatDate: ->
     format = "%b %e"
@@ -177,6 +186,10 @@ relativeTimeOrDate = (date) ->
 
 relativeWeekday = (date) ->
   if day = new RelativeTime(date).relativeWeekday()
+    day.charAt(0).toUpperCase() + day.substring(1)
+
+relativeCloseWeekday = (date) ->
+  if day = new RelativeTime(date).relativeCloseWeekday()
     day.charAt(0).toUpperCase() + day.substring(1)
 
 
@@ -229,6 +242,8 @@ document.addEventListener "DOMContentLoaded", ->
           relativeWeekday(time) ? ""
         when "weekday-or-date"
           relativeWeekday(time) ? relativeDate(time)
+        when "close-weekday-or-date"
+          relativeCloseWeekday(time) ? strftime(time, '%b %e, %a')
 
 run = ->
   event = document.createEvent "Events"
@@ -238,4 +253,4 @@ run = ->
 setInterval run, 60 * 1000
 
 # Public API
-@LocalTime = {relativeDate, relativeTimeAgo, relativeTimeOrDate, relativeWeekday, run, strftime}
+@LocalTime = {relativeDate, relativeTimeAgo, relativeTimeOrDate, relativeWeekday, relativeCloseWeekday, run, strftime}


### PR DESCRIPTION
The new local_relative_time type: 'close-weekday-or-date' shows Yesterday, Today and Tomorrow names for date if it falls into the timespan. Otherwise it shows a date in format '%b %e, %a'