### PR TITLE
Adding %o to get the unpadded month num

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To use a strftime format already defined in your app, pass a symbol as the forma
 
 `I18n.t("time.formats.#{format}")`, `I18n.t("date.formats.#{format}")`, `Time::DATE_FORMATS[format]`, and `Date::DATE_FORMATS[format]` will be scanned (in that order) for your format.
 
-Note: The included strftime JavaScript implementation is not 100% complete. It supports the following directives: `%a %A %b %B %c %d %e %H %I %l %m %M %p %P %S %w %y %Y %Z`
+Note: The included strftime JavaScript implementation is not 100% complete. It supports the following directives: `%a %A %b %B %c %d %e %H %I %l %m %M %o %p %P %S %w %y %Y %Z`
 
 #### Time ago helper
 

--- a/app/assets/javascripts/local_time.js.coffee
+++ b/app/assets/javascripts/local_time.js.coffee
@@ -49,7 +49,7 @@ strftime = (time, formatString) ->
   minute = time.getMinutes()
   second = time.getSeconds()
 
-  formatString.replace /%([%aAbBcdeHIlmMpPSwyYZ])/g, ([match, modifier]) ->
+  formatString.replace /%([%aAbBcdeHIlmMopPSwyYZ])/g, ([match, modifier]) ->
     switch modifier
       when '%' then '%'
       when 'a' then weekdays[day].slice 0, 3
@@ -64,6 +64,7 @@ strftime = (time, formatString) ->
       when 'l' then (if hour is 0 or hour is 12 then 12 else (hour + 12) % 12)
       when 'm' then pad month + 1
       when 'M' then pad minute
+      when 'o' then month + 1
       when 'p' then (if hour > 11 then 'PM' else 'AM')
       when 'P' then (if hour > 11 then 'pm' else 'am')
       when 'S' then pad second

--- a/test/javascripts/src/strftime_test.js.coffee
+++ b/test/javascripts/src/strftime_test.js.coffee
@@ -13,6 +13,7 @@ momentMap =
   "%l": "h"
   "%m": "MM"
   "%M": "mm"
+  "%o": "M"
   "%p": "A"
   "%P": "a"
   "%S": "ss"


### PR DESCRIPTION
Mimicking the `%-m` functionality of ruby. Since `%e` already
mimicks `%-d` (#45), it seemed better to take the same approach
for the unpadded month as oppossed to actually fully
implementing the `-`.

The letter `o` was chosen arbitrarily.