### PR TITLE
Listen for turbolinks:load event

### DIFF
--- a/app/assets/javascripts/local_time.js.coffee
+++ b/app/assets/javascripts/local_time.js.coffee
@@ -200,7 +200,8 @@ update = (callback) ->
   document.addEventListener "time:elapse", callback
 
   if Turbolinks?.supported
-    document.addEventListener "page:update", callback
+    for event in ["page:update", "turbolinks:load"]
+      document.addEventListener event, callback
   else
     jQuery?(document).on "ajaxSuccess", (event, xhr) ->
       callback() if jQuery.trim xhr.responseText

--- a/test/javascripts/src/page_events_test.js.coffee
+++ b/test/javascripts/src/page_events_test.js.coffee
@@ -13,13 +13,21 @@ test "document time:elapse", ->
 test "document page:update with Turbolinks on", ->
   el = addTimeEl()
   triggerEvent "page:update"
+  triggerEvent "turbolinks:load"
   ok not getText el
 
   original = window.Turbolinks
   window.Turbolinks = { supported: true }
 
   triggerEvent "DOMContentLoaded"
+
+  el2 = addTimeEl()
   triggerEvent "page:update"
-  ok getText el
+  ok getText el2
+
+  # Turbolinks 5
+  el3 = addTimeEl()
+  triggerEvent "turbolinks:load"
+  ok getText el3
 
   window.Turbolinks = original


### PR DESCRIPTION
This adds the turbolinks:load event that Turbolinks5 uses rather than page:change
