### PR TITLE
allow for the default format to be set

### DIFF
--- a/app/helpers/local_time_helper.rb
+++ b/app/helpers/local_time_helper.rb
@@ -1,6 +1,14 @@
 module LocalTimeHelper
   DEFAULT_FORMAT = '%B %e, %Y %l:%M%P'
 
+  def self.set_default_format(string)
+    @default_format = format
+  end
+
+  def self.default_format
+    @default_format ||= DEFAULT_FORMAT
+  end
+
   def local_time(time, options = nil)
     time = utc_time(time)
 
@@ -26,7 +34,7 @@ module LocalTimeHelper
     options[:data] ||= {}
     options[:data].merge! local: type
 
-    time_tag time, time.strftime(DEFAULT_FORMAT), options
+    time_tag time, time.strftime(LocalTimeHelper.default_format), options
   end
 
   def local_time_ago(time, options = nil)
@@ -49,12 +57,12 @@ module LocalTimeHelper
         if (i18n_format = I18n.t("time.formats.#{format}", default: [:"date.formats.#{format}", ''])).present?
           i18n_format
         elsif (date_format = Time::DATE_FORMATS[format] || Date::DATE_FORMATS[format])
-          date_format.is_a?(Proc) ? DEFAULT_FORMAT : date_format
+          date_format.is_a?(Proc) ? LocalTimeHelper.default_format : date_format
         else
-          DEFAULT_FORMAT
+          LocalTimeHelper.default_format
         end
       else
-        format.presence || DEFAULT_FORMAT
+        format.presence || LocalTimeHelper.default_format
       end
     end
 


### PR DESCRIPTION
Currently when trying to change the default format like such:

``` ruby
LocalTimeHelper::DEFAULT_FORMAT = Time::DATE_FORMATS[:default]
```

You end up with a warning, like such:

```
local_time-1.0.3/app/helpers/local_time_helper.rb:2: warning: previous definition of DEFAULT_FORMAT was here
```

This PR adds a getter/setter for setting this default without the warning.
