### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Local Time is a Rails engine with helpers and JavaScript for displaying times an
 
 ---
 
-####Example
+#### Example
 
 ```ruby
 > comment.created_at


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
