### PR TITLE
Bump blade dependencies

### DIFF
--- a/local_time.gemspec
+++ b/local_time.gemspec
@@ -13,6 +13,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rails"
   s.add_development_dependency "rails-dom-testing"
-  s.add_development_dependency "blade", "0.4.1"
-  s.add_development_dependency "blade-sauce_labs_plugin", "0.4.1"
+  s.add_development_dependency "blade", "0.7.0"
+  s.add_development_dependency "blade-sauce_labs_plugin", "0.7.1"
 end


### PR DESCRIPTION
Bumps `blade` and `blade-sauce_labs_plugin` to latest versions.