### PR TITLE
add guard clause for nil value

### DIFF
--- a/app/helpers/local_time_helper.rb
+++ b/app/helpers/local_time_helper.rb
@@ -1,5 +1,7 @@
 module LocalTimeHelper
   def local_time(time, options = nil)
+    return nil if time == nil
+
     time = utc_time(time)
 
     options, format = extract_options_and_value(options, :format)

--- a/test/helpers/local_time_helper_test.rb
+++ b/test/helpers/local_time_helper_test.rb
@@ -59,6 +59,11 @@ class LocalTimeHelperTest < TestCase
     assert_dom_equal expected, local_time(@time)
   end
 
+  def test_local_time_with_nil
+    expected = nil
+    assert_dom_equal expected, local_time(nil)
+  end
+
   def test_local_time_with_format
     expected = %Q(<time data-format="%b %e" data-local="time" datetime="#{@time_js}">Nov 21</time>)
     assert_dom_equal expected, local_time(@time, format: '%b %e')


### PR DESCRIPTION
Add guard clause to prevent #local_time and #local_date to crash the application when `nil` is provided. 

