### PR TITLE
Fix timezone parsing to handle Hawaiian-Aleutian Standard Time

### DIFF
--- a/lib/assets/javascripts/src/local-time/helpers/strftime.coffee
+++ b/lib/assets/javascripts/src/local-time/helpers/strftime.coffee
@@ -40,7 +40,7 @@ pad = (num, flag) ->
 parseTimeZone = (time) ->
   string = time.toString()
   # Sun Aug 30 2015 10:22:57 GMT-0400 (NAME)
-  if name = string.match(/\(([\w\s]+)\)$/)?[1]
+  if name = string.match(/\(([\w\s-]+)\)$/)?[1]
     if /\s/.test(name)
       # Sun Aug 30 2015 10:22:57 GMT-0400 (Eastern Daylight Time)
       name.match(/\b(\w)/g).join("")


### PR DESCRIPTION
### Current bug
Timezones like "Hawaiian-Aleutian Standard Time" should render as HAST, but the current regex only captures characters and won't match "Hawaiian-Aleutian" due to the dash in the middle.

### Suggested fix
Include dashes in the regex