### PR TITLE
Update readme install section for Rails 6 with Webpacker

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,20 +7,20 @@ Local Time makes it easy to display times and dates to users in their local time
 1. Add `gem 'local_time'` to your Gemfile.
 2. Include `local-time.js` in your application's JavaScript bundle.
 
-    Using the asset pipeline:
+ 1. Using the asset pipeline:
     ```js
     //= require local-time
     ```
-    Using the [local-time npm package](https://www.npmjs.com/package/local-time):
+ 1. Using the [local-time npm package](https://www.npmjs.com/package/local-time):
     ```js
     import LocalTime from "local-time"
     LocalTime.start()
     ```
 
-    Using Ruby on Rails 6 with Webpacker:
+ 1. Using Ruby on Rails 6 with Webpacker:
 
     1. Add `local-time` to `package.json`
-       ```json
+       ```
        {
          [...]
          "dependencies": {

--- a/README.md
+++ b/README.md
@@ -7,38 +7,36 @@ Local Time makes it easy to display times and dates to users in their local time
 1. Add `gem 'local_time'` to your Gemfile.
 2. Include `local-time.js` in your application's JavaScript bundle.
 
- 1. Using the asset pipeline:
-    ```js
-    //= require local-time
-    ```
- 1. Using the [local-time npm package](https://www.npmjs.com/package/local-time):
-    ```js
-    import LocalTime from "local-time"
-    LocalTime.start()
-    ```
+   1. Using the asset pipeline:
+      ```js
+      //= require local-time
+      ```
 
- 1. Using Ruby on Rails 6 with Webpacker:
+   1. Using the [local-time npm package](https://www.npmjs.com/package/local-time):
+      ```js
+      import LocalTime from "local-time"
+      LocalTime.start()
+      ```
 
-    1. Add `local-time` to `package.json`
-       ```
-       {
-         [...]
-         "dependencies": {
-           [...],
-           "local-time": "^2.1.0"
-         },
-         [...]
-       }
-       ```
-    1. Run `yarn install` to install npm packages
-       ```sh
-       $ yarn install
-       [...] Resolving packages ...
-       ```
-    1. Add `local-time` to `app/javascript/packs/application.js`
-       ```js
-       require("local-time").start()
-       ```
+   1. Using Ruby on Rails 6 with Webpacker:
+
+      1. Add `local-time` to `package.json`
+         ```json
+         {
+           "dependencies": {
+             "local-time": "^2.1.0"
+           }
+         }
+         ```
+      1. Run `yarn install` to install npm packages
+         ```sh
+         $ yarn install
+         [...] Resolving packages ...
+         ```
+      1. Add `local-time` to `app/javascript/packs/application.js`
+         ```js
+         require("local-time").start()
+         ```
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,29 @@ Local Time makes it easy to display times and dates to users in their local time
     LocalTime.start()
     ```
 
+    Using Ruby on Rails 6 with Webpacker:
+
+    1. Add `local-time` to `package.json`
+       ```json
+       {
+         [...]
+         "dependencies": {
+           [...],
+           "local-time": "^2.1.0"
+         },
+         [...]
+       }
+       ```
+    1. Run `yarn install` to install npm packages
+       ```sh
+       $ yarn install
+       [...] Resolving packages ...
+       ```
+    1. Add `local-time` to `app/javascript/packs/application.js`
+       ```js
+       require("local-time").start()
+       ```
+
 ## Example
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -20,17 +20,9 @@ Local Time makes it easy to display times and dates to users in their local time
 
    1. Using Ruby on Rails 6 with Webpacker:
 
-      1. Add `local-time` to `package.json`
-         ```json
-         {
-           "dependencies": {
-             "local-time": "^2.1.0"
-           }
-         }
-         ```
-      1. Run `yarn install` to install npm packages
+      1. Add `local-time` to `package.json` with `yarn add local-time`
          ```sh
-         $ yarn install
+         $ yarn add local-time
          [...] Resolving packages ...
          ```
       1. Add `local-time` to `app/javascript/packs/application.js`


### PR DESCRIPTION
Documentation update in README.md to add instructions for using `local_time` with Ruby on Rails 6 with Webpacker.

I struggled to find instructions on how to use `local_time` with Ruby on Rails 6 and Webpacker. Based on a [comment on Stack Overflow](https://stackoverflow.com/a/58404848), I figured how to do it and updated README.md.

I am happy to edit this PR to your requirements, and please feel free to update/delete as you like :-)