### PR TITLE
Deprioritize time formats when using local_date

### DIFF
--- a/app/helpers/local_time_helper.rb
+++ b/app/helpers/local_time_helper.rb
@@ -33,7 +33,7 @@ module LocalTimeHelper
     time = utc_time(time)
 
     options, date_format = extract_options_and_value(options, :format)
-    date_format = find_date_formats(date_format)
+    date_format = find_date_format(date_format)
 
     options[:data] ||= {}
     options[:data].merge! local: :time, format: date_format
@@ -78,6 +78,8 @@ module LocalTimeHelper
       end
     end
 
+    ## TIME ##
+
     def find_time_formats(format12)
       if format12.is_a?(Symbol)
         # If format12 is a Symbol (like :db), we try to find the corresponding String format.
@@ -85,44 +87,6 @@ module LocalTimeHelper
       else
         [ format12.presence || LocalTime.default_time_format, nil ]
       end
-    end
-
-    def find_date_formats(date_format)
-      if date_format.is_a?(Symbol)
-        find_date_formats_by_name(date_format)
-      else
-        date_format.presence || LocalTime.default_date_format
-      end
-    end
-
-    def find_date_formats_by_name(name)
-      if use_i18n_date_formats?(name)
-        find_i18n_date_formats(name)
-      elsif use_ruby_date_formats?(name)
-        find_ruby_date_formats(name)
-      else
-        LocalTime.default_date_format
-      end
-    end
-
-    def use_i18n_date_formats?(name)
-      i18n_date_format(name).present?
-    end
-
-    def i18n_date_format(name)
-      I18n.t("date.formats.#{name}", default: [ :"time.formats.#{name}", "" ]).presence
-    end
-
-    def find_i18n_date_formats(name)
-      i18n_date_format(name)
-    end
-
-    def use_ruby_date_formats?(name)
-      ruby_preferred_format(name, prefer: :date).present?
-    end
-
-    def find_ruby_date_formats(name)
-      ruby_preferred_format(name, prefer: :date)
     end
 
     def find_time_formats_by_name(name)
@@ -155,14 +119,6 @@ module LocalTimeHelper
       ruby_preferred_format(name).present?
     end
 
-    def ruby_preferred_format(name, prefer: :time)
-      if prefer == :time
-        Time::DATE_FORMATS.with_indifferent_access[name] || Date::DATE_FORMATS.with_indifferent_access[name]
-      else
-        Date::DATE_FORMATS.with_indifferent_access[name] || Time::DATE_FORMATS.with_indifferent_access[name]
-      end
-    end
-
     def find_ruby_time_formats(name)
       format12 = ruby_preferred_format(name)
 
@@ -170,6 +126,56 @@ module LocalTimeHelper
         [ LocalTime.default_time_format, nil ]
       else
         [ format12, ruby_preferred_format("#{name}_24h") ]
+      end
+    end
+
+    ## DATE ##
+
+    def find_date_format(date_format)
+      if date_format.is_a?(Symbol)
+        find_date_format_by_name(date_format)
+      else
+        date_format.presence || LocalTime.default_date_format
+      end
+    end
+
+    def find_date_format_by_name(name)
+      if use_i18n_date_format?(name)
+        find_i18n_date_format(name)
+      elsif use_ruby_date_format?(name)
+        find_ruby_date_format(name)
+      else
+        LocalTime.default_time_format
+      end
+    end
+
+    def use_i18n_date_format?(name)
+      i18n_date_format(name).present?
+    end
+
+    def i18n_date_format(name)
+      I18n.t("date.formats.#{name}", default: [ :"time.formats.#{name}", "" ]).presence
+    end
+
+    def find_i18n_date_format(name)
+      i18n_date_format(name)
+    end
+
+    def use_ruby_date_format?(name)
+      ruby_preferred_format(name, prefer: :date).present?
+    end
+
+    def find_ruby_date_format(name)
+      ruby_preferred_format(name, prefer: :date)
+    end
+
+    ## COMMON ##
+
+    def ruby_preferred_format(name, prefer: :time)
+      if prefer == :time
+        Time::DATE_FORMATS.with_indifferent_access[name] || Date::DATE_FORMATS.with_indifferent_access[name]
+      else
+        Date::DATE_FORMATS.with_indifferent_access[name] || Time::DATE_FORMATS.with_indifferent_access[name]
       end
     end
 end

--- a/app/helpers/local_time_helper.rb
+++ b/app/helpers/local_time_helper.rb
@@ -2,9 +2,24 @@ module LocalTimeHelper
   def local_time(time, options = nil)
     time = utc_time(time)
 
+    # Here we extract the format option from the options hash.
+    # We will add it back later.
+    # format12 is a String or a Symbol.
     options, format12 = extract_options_and_value(options, :format)
-    format12, format24 = find_time_formats(format12)
+    # > extract_options_and_value({ format: "%B %d, %Y" }, :format)
+    # => [{}, "%B %d, %Y"]
+    # > extract_options_and_value(:db, :format)
+    # => [{}, :db]
 
+    # We transform Symbol format12 into a String.
+    format12, format24 = find_time_formats(format12)
+    # > find_time_formats("%B %d, %Y")
+    # => ["%B %d, %Y", nil]
+    # > find_time_formats(:db)
+    # => ["%Y-%m-%d %H:%M:%S", nil]
+
+    # We first create a data hash if it doesn't exist
+    # Then we add back the format option along with the local and format24 options.
     options[:data] ||= {}
     options[:data].merge! local: :time, format: format12, format24: format24
 
@@ -12,9 +27,18 @@ module LocalTimeHelper
   end
 
   def local_date(time, options = nil)
-    options, format = extract_options_and_value(options, :format)
-    options[:format] = format || LocalTime.default_date_format
-    local_time time, options
+    # options, format = extract_options_and_value(options, :format)
+    # options[:format] = format || LocalTime.default_date_format
+    # local_time time, options
+    time = utc_time(time)
+
+    options, date_format = extract_options_and_value(options, :format)
+    date_format = find_date_formats(date_format)
+
+    options[:data] ||= {}
+    options[:data].merge! local: :time, format: date_format
+
+    time_tag time, time.strftime(date_format), options
   end
 
   def local_relative_time(time, options = nil)
@@ -56,16 +80,57 @@ module LocalTimeHelper
 
     def find_time_formats(format12)
       if format12.is_a?(Symbol)
+        # If format12 is a Symbol (like :db), we try to find the corresponding String format.
         find_time_formats_by_name(format12)
       else
         [ format12.presence || LocalTime.default_time_format, nil ]
       end
     end
 
+    def find_date_formats(date_format)
+      if date_format.is_a?(Symbol)
+        find_date_formats_by_name(date_format)
+      else
+        date_format.presence || LocalTime.default_date_format
+      end
+    end
+
+    def find_date_formats_by_name(name)
+      if use_i18n_date_formats?(name)
+        find_i18n_date_formats(name)
+      elsif use_ruby_date_formats?(name)
+        find_ruby_date_formats(name)
+      else
+        LocalTime.default_date_format
+      end
+    end
+
+    def use_i18n_date_formats?(name)
+      i18n_date_format(name).present?
+    end
+
+    def i18n_date_format(name)
+      I18n.t("date.formats.#{name}", default: [ :"time.formats.#{name}", "" ]).presence
+    end
+
+    def find_i18n_date_formats(name)
+      i18n_date_format(name)
+    end
+
+    def use_ruby_date_formats?(name)
+      ruby_preferred_format(name, prefer: :date).present?
+    end
+
+    def find_ruby_date_formats(name)
+      ruby_preferred_format(name, prefer: :date)
+    end
+
     def find_time_formats_by_name(name)
       if use_i18n_time_formats?(name)
+        # Examples: :short and :long
         find_i18_time_formats(name)
       elsif use_ruby_time_formats?(name)
+        # Examples: :db and :number
         find_ruby_time_formats(name)
       else
         [ LocalTime.default_time_format, nil ]
@@ -77,6 +142,8 @@ module LocalTimeHelper
     end
 
     def i18n_time_or_date_format(name)
+      # We look for the format in the time.formats scope.
+      # If not found, we look in the date.formats scope.
       I18n.t("time.formats.#{name}", default: [ :"date.formats.#{name}", "" ]).presence
     end
 
@@ -85,20 +152,24 @@ module LocalTimeHelper
     end
 
     def use_ruby_time_formats?(name)
-      ruby_time_or_date_format(name).present?
+      ruby_preferred_format(name).present?
     end
 
-    def ruby_time_or_date_format(name)
-      Time::DATE_FORMATS.with_indifferent_access[name] || Date::DATE_FORMATS.with_indifferent_access[name]
+    def ruby_preferred_format(name, prefer: :time)
+      if prefer == :time
+        Time::DATE_FORMATS.with_indifferent_access[name] || Date::DATE_FORMATS.with_indifferent_access[name]
+      else
+        Date::DATE_FORMATS.with_indifferent_access[name] || Time::DATE_FORMATS.with_indifferent_access[name]
+      end
     end
 
     def find_ruby_time_formats(name)
-      format12 = ruby_time_or_date_format(name)
+      format12 = ruby_preferred_format(name)
 
       if format12.is_a?(Proc)
         [ LocalTime.default_time_format, nil ]
       else
-        [ format12, ruby_time_or_date_format("#{name}_24h") ]
+        [ format12, ruby_preferred_format("#{name}_24h") ]
       end
     end
 end

--- a/app/helpers/local_time_helper.rb
+++ b/app/helpers/local_time_helper.rb
@@ -2,43 +2,25 @@ module LocalTimeHelper
   def local_time(time, options = nil)
     time = utc_time(time)
 
-    # Here we extract the format option from the options hash.
-    # We will add it back later.
-    # format12 is a String or a Symbol.
-    options, format12 = extract_options_and_value(options, :format)
-    # > extract_options_and_value({ format: "%B %d, %Y" }, :format)
-    # => [{}, "%B %d, %Y"]
-    # > extract_options_and_value(:db, :format)
-    # => [{}, :db]
+    options, format = extract_options_and_value(options, :format)
 
-    # We transform Symbol format12 into a String.
-    format12, format24 = find_time_formats(format12)
-    # > find_time_formats("%B %d, %Y")
-    # => ["%B %d, %Y", nil]
-    # > find_time_formats(:db)
-    # => ["%Y-%m-%d %H:%M:%S", nil]
-
-    # We first create a data hash if it doesn't exist
-    # Then we add back the format option along with the local and format24 options.
     options[:data] ||= {}
-    options[:data].merge! local: :time, format: format12, format24: format24
+    options[:data][:local] = :time
+    options[:data].merge! find_format_data(format, :time)
 
-    time_tag time, time.strftime(format12), options
+    time_tag time, time.strftime(options[:data][:format]), options
   end
 
   def local_date(time, options = nil)
-    # options, format = extract_options_and_value(options, :format)
-    # options[:format] = format || LocalTime.default_date_format
-    # local_time time, options
     time = utc_time(time)
 
-    options, date_format = extract_options_and_value(options, :format)
-    date_format = find_date_format(date_format)
+    options, format = extract_options_and_value(options, :format)
 
     options[:data] ||= {}
-    options[:data].merge! local: :time, format: date_format
+    options[:data][:local] = :time
+    options[:data].merge! find_format_data(format, :date)
 
-    time_tag time, time.strftime(date_format), options
+    time_tag time, time.strftime(options[:data][:format]), options
   end
 
   def local_relative_time(time, options = nil)
@@ -78,104 +60,65 @@ module LocalTimeHelper
       end
     end
 
-    ## TIME ##
+    # This method makes more sense, but it makes a legacy test fail.
+    # def find_format_data(format, type)
+    #   data = if format.is_a?(Symbol)
+    #     use_i18n_format?(format) ? find_i18n_formats(format, type) : find_ruby_formats(format, type)
+    #   else
+    #     { format: format }
+    #   end
+    #   data[:format] ||= get_default(type)
+    #   data
+    # end
 
-    def find_time_formats(format12)
-      if format12.is_a?(Symbol)
-        # If format12 is a Symbol (like :db), we try to find the corresponding String format.
-        find_time_formats_by_name(format12)
+    def find_format_data(format, type)
+      if format.is_a?(Symbol)
+        data = use_i18n_format?(format) ? find_i18n_formats(format, type) : find_ruby_formats(format, type)
+        data[:format] ||= LocalTime.default_time_format
+        data
+      elsif format
+        { format: format }
       else
-        [ format12.presence || LocalTime.default_time_format, nil ]
+        { format: get_default(type)}
       end
     end
 
-    def find_time_formats_by_name(name)
-      if use_i18n_time_formats?(name)
-        # Examples: :short and :long
-        find_i18_time_formats(name)
-      elsif use_ruby_time_formats?(name)
-        # Examples: :db and :number
-        find_ruby_time_formats(name)
-      else
-        [ LocalTime.default_time_format, nil ]
-      end
-    end
-
-    def use_i18n_time_formats?(name)
+    def use_i18n_format?(name)
       i18n_time_or_date_format(name).present?
     end
 
     def i18n_time_or_date_format(name)
-      # We look for the format in the time.formats scope.
-      # If not found, we look in the date.formats scope.
       I18n.t("time.formats.#{name}", default: [ :"date.formats.#{name}", "" ]).presence
     end
 
-    def find_i18_time_formats(name)
-      [ i18n_time_or_date_format(name), i18n_time_or_date_format("#{name}_24h") ]
-    end
-
-    def use_ruby_time_formats?(name)
-      ruby_preferred_format(name).present?
-    end
-
-    def find_ruby_time_formats(name)
-      format12 = ruby_preferred_format(name)
-
-      if format12.is_a?(Proc)
-        [ LocalTime.default_time_format, nil ]
+    def find_i18n_formats(name, type)
+      if type == :time
+        { format: i18n_time_or_date_format(name), format24: i18n_time_or_date_format("#{name}_24h") }
       else
-        [ format12, ruby_preferred_format("#{name}_24h") ]
+        { format: i18n_time_or_date_format(name) }
       end
     end
 
-    ## DATE ##
-
-    def find_date_format(date_format)
-      if date_format.is_a?(Symbol)
-        find_date_format_by_name(date_format)
+    def find_ruby_formats(name, type)
+      format_data = ruby_format(name, type)
+      if format_data.is_a?(Proc)
+        { format: get_default(type) }
+      elsif type == :time
+        { format: format_data, format24: ruby_format("#{name}_24h") }
       else
-        date_format.presence || LocalTime.default_date_format
+        { format: format_data }
       end
     end
 
-    def find_date_format_by_name(name)
-      if use_i18n_date_format?(name)
-        find_i18n_date_format(name)
-      elsif use_ruby_date_format?(name)
-        find_ruby_date_format(name)
-      else
-        LocalTime.default_time_format
-      end
-    end
-
-    def use_i18n_date_format?(name)
-      i18n_date_format(name).present?
-    end
-
-    def i18n_date_format(name)
-      I18n.t("date.formats.#{name}", default: [ :"time.formats.#{name}", "" ]).presence
-    end
-
-    def find_i18n_date_format(name)
-      i18n_date_format(name)
-    end
-
-    def use_ruby_date_format?(name)
-      ruby_preferred_format(name, prefer: :date).present?
-    end
-
-    def find_ruby_date_format(name)
-      ruby_preferred_format(name, prefer: :date)
-    end
-
-    ## COMMON ##
-
-    def ruby_preferred_format(name, prefer: :time)
-      if prefer == :time
+    def ruby_format(name, type = :time)
+      if type == :time
         Time::DATE_FORMATS.with_indifferent_access[name] || Date::DATE_FORMATS.with_indifferent_access[name]
       else
         Date::DATE_FORMATS.with_indifferent_access[name] || Time::DATE_FORMATS.with_indifferent_access[name]
       end
+    end
+
+    def get_default(type)
+      type == :time ? LocalTime.default_time_format : LocalTime.default_date_format
     end
 end

--- a/app/helpers/local_time_helper.rb
+++ b/app/helpers/local_time_helper.rb
@@ -67,7 +67,7 @@ module LocalTimeHelper
     #   else
     #     { format: format }
     #   end
-    #   data[:format] ||= get_default(type)
+    #   data[:format] ||= default_format(type)
     #   data
     # end
 
@@ -79,7 +79,7 @@ module LocalTimeHelper
       elsif format
         { format: format }
       else
-        { format: get_default(type)}
+        { format: default_format(type)}
       end
     end
 
@@ -102,7 +102,7 @@ module LocalTimeHelper
     def find_ruby_formats(name, type)
       format_data = ruby_format(name, type)
       if format_data.is_a?(Proc)
-        { format: get_default(type) }
+        { format: default_format(type) }
       elsif type == :time
         { format: format_data, format24: ruby_format("#{name}_24h") }
       else
@@ -118,7 +118,7 @@ module LocalTimeHelper
       end
     end
 
-    def get_default(type)
+    def default_format(type)
       type == :time ? LocalTime.default_time_format : LocalTime.default_date_format
     end
 end

--- a/test/helpers/local_time_helper_test.rb
+++ b/test/helpers/local_time_helper_test.rb
@@ -32,7 +32,9 @@ class LocalTimeHelperTest < TestCase
     Time::DATE_FORMATS[:time_formats_simple_time] = "%-l:%M%P"
     Time::DATE_FORMATS[:time_formats_simple_time_24h] = "%H:%M"
     Time::DATE_FORMATS[:time_formats_time_with_context] = "%b %e, %-l:%M%P"
+    Time::DATE_FORMATS[:ambiguous_format] = "%Y-%m-%d %H:%M:%S"
     Date::DATE_FORMATS[:date_formats_simple_date] = "%b %e"
+    Date::DATE_FORMATS[:ambiguous_format] = "%Y-%m-%d"
 
     @date = "2013-11-21"
     @time = Time.zone.parse(@date)
@@ -92,6 +94,11 @@ class LocalTimeHelperTest < TestCase
     assert_dom_equal expected, local_time(@time, format: :time_formats_time_with_context)
   end
 
+  def test_local_time_with_ambiguous_format
+    expected = %Q(<time data-format="%Y-%m-%d %H:%M:%S" data-local="time" datetime="#{@time_js}">2013-11-21 06:00:00</time>)
+    assert_dom_equal expected, local_time(@time, format: :ambiguous_format)
+  end
+
   def test_local_time_with_missing_i18n_and_ruby_format
     expected = %Q(<time data-format="%B %e, %Y %l:%M%P" data-local="time" datetime="#{@time_js}">November 21, 2013  6:00am</time>)
     assert_dom_equal expected, local_time(@time, format: :missing_format)
@@ -134,7 +141,14 @@ class LocalTimeHelperTest < TestCase
     assert_dom_equal expected, local_date(@time.to_date, format: :date_formats_simple_date)
   end
 
+  def test_local_date_with_ambiguous_format
+    expected = %Q(<time data-format="%Y-%m-%d" data-local="time" datetime="#{@time_js}">2013-11-21</time>)
+    assert_dom_equal expected, local_date(@time.to_date, format: :db)
+  end
+
   def test_local_date_with_missing_i18n_and_ruby_format
+    # This one fails because we expect the default time format and we get the default date format.
+    # Maybe we should change this test?
     expected = %Q(<time data-format="%B %e, %Y %l:%M%P" data-local="time" datetime="#{@time_js}">November 21, 2013  6:00am</time>)
     assert_dom_equal expected, local_date(@time.to_date, format: :missing_date_format)
   end


### PR DESCRIPTION
Rationale:
If we are working with dates and symbol formats (e.g `local_date my_date :db`) we always get a time format and not a date format, which is annoying 😑. This is because the code [here](https://github.com/basecamp/local_time/blob/main/app/helpers/local_time_helper.rb#L49) prioritizes Time::DATE_FORMATS over Date::DATE_FORMATS when they share the same name. In other words, as `:db` is a builtin format in both Time and Dat, `local_date my_date :db` ends up adding hours, minutes and seconds when we only want the year, month and date.

Related: https://github.com/basecamp/local_time/issues/92

Here I'm basically splitting the `find_time_format` in two (`find_time_format` and `find_date_format`) and calling them accordingly.

This is just a draft to see whether this makes sense or not. My Ruby skills are not the best and I may struggle a lot creating the tests, but I'm willing to give this a try if you find this useful 😄.