### PR TITLE
Don't start LocalTime automatically

### DIFF
--- a/lib/assets/javascripts/src/local-time/start.coffee
+++ b/lib/assets/javascripts/src/local-time/start.coffee
@@ -22,6 +22,3 @@ LocalTime.start = ->
       startController()
     else
       nextFrame(startController)
-
-if window.LocalTime is LocalTime
-  LocalTime.start()


### PR DESCRIPTION
# Description

The readme states that one should call `LocalTime.start()` manually. Yet, the library is automatically calling this for you. This is causing LocalTime to ignore any configuration, because it's starting before the configuration is set.

By removing the automatic starting, the user is given control to set the appropriate configuration and then, start the `LocalTime` instance.


e.g.

```js
import LocalTime from "local-time";

LocalTime.config.i18n["es"] = {
  // ...
}

console.log(LocalTime.config.i18n.es)
// Returns the "es" config, yet the timestamps have already 
// been localized using "en"
```

This is happening when using rollup.js in IIFE mode:

```js
import resolve from "@rollup/plugin-node-resolve";
import commonjs from "@rollup/plugin-commonjs";
import terser from "@rollup/plugin-terser";

const isProductionBuild = process.env.BUILD_ENV === "production";

const commonOutputOptions = {
  format: "iife",
  inlineDynamicImports: true,
  sourcemap: !isProductionBuild,
};

const inputs = ["admin", "front"];

const configs = inputs.map((input) => {
  const plugins = [commonjs(), resolve({ browser: true })];

  if (isProductionBuild) {
    plugins.push(terser());
  }

  return {
    input: `app/javascript/${input}.js`,
    plugins: plugins,
    output: {
      ...commonOutputOptions,
      file: `app/assets/builds/${input}.js`,
    },
  };
});

export default configs;
```

Example result:

<img width="513" alt="image" src="https://github.com/basecamp/local_time/assets/15317732/8b206063-308e-441b-88f0-7929907efea4">

# Note

This might be a breaking change, and this probably should've been an issue first, but I spent hours debugging this, so figured I'd just go ahead and make the PR.