### PR TITLE
Fix flaky `relative weekdate or date: date before this week` test

### DIFF
--- a/test/javascripts/src/relative_date_test.js
+++ b/test/javascripts/src/relative_date_test.js
@@ -1,6 +1,6 @@
 import LocalTime from "local_time"
 
-const { addTimeEl, assert, defer, getText, testAsync, testGroup, mockNow } = LocalTime.TestHelpers
+const { addTimeEl, assert, defer, getText, testAsync, testGroup, stubNow } = LocalTime.TestHelpers
 
 testGroup("relative date", () => {
   testAsync("this year", (done) => {
@@ -109,7 +109,7 @@ testGroup("relative weekday or date", () => {
   })
 
   testAsync("before this week", (done) => {
-    mockNow(`${moment().year()}-03-20`, () => {
+    stubNow(`${moment().year()}-03-20`, () => {
       const before = moment().subtract("days", 8)
       const el = addTimeEl({ type: "weekday-or-date", datetime: before.toISOString() })
       defer(() => {

--- a/test/javascripts/src/relative_date_test.js
+++ b/test/javascripts/src/relative_date_test.js
@@ -1,6 +1,6 @@
 import LocalTime from "local_time"
 
-const { addTimeEl, assert, defer, getText, setText, test, testAsync, testGroup, triggerEvent } = LocalTime.TestHelpers
+const { addTimeEl, assert, defer, getText, testAsync, testGroup, mockNow } = LocalTime.TestHelpers
 
 testGroup("relative date", () => {
   testAsync("this year", (done) => {
@@ -109,11 +109,13 @@ testGroup("relative weekday or date", () => {
   })
 
   testAsync("before this week", (done) => {
-    const before = moment().subtract("days", 8)
-    const el = addTimeEl({ type: "weekday-or-date", datetime: before.toISOString() })
-    defer(() => {
-      assert.equal(getText(el), before.format("MMM D"))
-      done()
+    mockNow(`${moment().year()}-03-20`, () => {
+      const before = moment().subtract("days", 8)
+      const el = addTimeEl({ type: "weekday-or-date", datetime: before.toISOString() })
+      defer(() => {
+        assert.equal(getText(el), before.format("MMM D"))
+        done()
+      })
     })
   })
 })

--- a/test/javascripts/src/test_helpers.js
+++ b/test/javascripts/src/test_helpers.js
@@ -52,5 +52,15 @@ LocalTime.TestHelpers = {
 
   defer(callback) {
     setTimeout(callback, 1)
+  },
+
+  mockNow(dateString, callback) {
+    const originalNow = moment.now
+    try {
+      moment.now = () => new Date(dateString).getTime()
+      callback()
+    } finally {
+      moment.now = originalNow
+    }
   }
 }

--- a/test/javascripts/src/test_helpers.js
+++ b/test/javascripts/src/test_helpers.js
@@ -54,7 +54,7 @@ LocalTime.TestHelpers = {
     setTimeout(callback, 1)
   },
 
-  mockNow(dateString, callback) {
+  stubNow(dateString, callback) {
     const originalNow = moment.now
     try {
       moment.now = () => new Date(dateString).getTime()


### PR DESCRIPTION
This would fail a week from new year's because `CalendarDate.occursOnSameYearAs(date)` compares the literal year values.

We could also account for this edge case in the code instead. But I don't think it's worth complicating.